### PR TITLE
add documentation for using a negative `after` in GetEventlog()

### DIFF
--- a/docs/repository-openapi.json
+++ b/docs/repository-openapi.json
@@ -280,7 +280,7 @@
       "elephant.repository.GetEventlogRequest": {
         "properties": {
           "after": {
-            "description": "After specifies the event ID after which to start returning events.",
+            "description": "After specifies the event ID after which to start returning events. A negative value of -N will start from the N most recent events.",
             "type": "integer"
           },
           "batch_size": {

--- a/repository/service.pb.go
+++ b/repository/service.pb.go
@@ -288,7 +288,8 @@ type GetEventlogRequest struct {
 	sizeCache     protoimpl.SizeCache
 	unknownFields protoimpl.UnknownFields
 
-	// After specifies the event ID after which to start returning events.
+	// After specifies the event ID after which to start returning events. A
+	// negative value of -N will start from the N most recent events.
 	After int64 `protobuf:"varint,1,opt,name=after,proto3" json:"after,omitempty"`
 	// Wait is the maximum time to wait for new events. Defaults to 2000.
 	WaitMs int32 `protobuf:"varint,2,opt,name=wait_ms,json=waitMs,proto3" json:"wait_ms,omitempty"`

--- a/repository/service.proto
+++ b/repository/service.proto
@@ -111,7 +111,8 @@ message GetPermissionsResponse {
 }
 
 message GetEventlogRequest {
-  // After specifies the event ID after which to start returning events.
+  // After specifies the event ID after which to start returning events. A
+  // negative value of -N will start from the N most recent events.
   int64 after = 1;
   // Wait is the maximum time to wait for new events. Defaults to 2000.
   int32 wait_ms = 2;


### PR DESCRIPTION
A negative starting point -N is used to get the last N events in the log.