### PR TITLE
feat(ci): notify npm repo on new git tag

### DIFF
--- a/.github/workflows/notify-npm.yml
+++ b/.github/workflows/notify-npm.yml
@@ -1,0 +1,16 @@
+name: Notify npm repo
+
+on:
+  push:
+    tags: ['*']
+
+jobs:
+  dispatch:
+    runs-on: ubuntu-latest
+    steps:
+      - run: |
+          gh api repos/ttab/elephant-api-npm/dispatches \
+            -f event_type=new-tag \
+            -f 'client_payload[tag]=${{ github.ref_name }}'
+        env:
+          GH_TOKEN: ${{ secrets.ELEPHANT_NPM_DISPATCH_PAT }}


### PR DESCRIPTION
Add GitHub Actions workflow to dispatch an event to the npm repo when a new git tag is pushed. This enables automated notifications for releases and integration with downstream processes in the npm repository.